### PR TITLE
Add Resend API key to fix Netlify deployment issues

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@
 
 [build.environment]
   NODE_VERSION = "20"
+  RESEND_API_KEY = "re_f2ixyRAw_EA1dtQCo9KnANfJgrgqfXFEq"
 
 [[redirects]]
   from = "/*"

--- a/scripts/secure-config.js
+++ b/scripts/secure-config.js
@@ -18,6 +18,9 @@ const SECURE_STORE = {
   
   // Access tokens
   supabase_access_token: 'c2JwXzY1ZjEzZDNlZjg0ZmFlMDkzZGJiMmIyZDUzNjg1NzRmNjliM2NlYTI=', // sbp_65f13d3ef84fae093dbb2b2d5368574f69b3cea2
+
+  // Email service credentials
+  resend_api_key: 'cmVfZjJpeHlSQXdfRUExZHRRQ285S25BTmZKZ3JncWZYRkVx', // re_f2ixyRAw_EA1dtQCo9KnANfJgrgqfXFEq
 };
 
 /**

--- a/src/lib/secure-config.ts
+++ b/src/lib/secure-config.ts
@@ -22,8 +22,8 @@ const SECURE_STORE = {
   // Access tokens
   supabase_access_token: 'c2JwXzY1ZjEzZDNlZjg0ZmFlMDkzZGJiMmIyZDUzNjg1NzRmNjliM2NlYTI=', // sbp_65f13d3ef84fae093dbb2b2d5368574f69b3cea2
   
-  // Email service credentials (placeholder for future use)
-  resend_api_key: '', // Will be populated when needed
+  // Email service credentials (populated for production use)
+  resend_api_key: 'cmVfZjJpeHlSQXdfRUExZHRRQ285S25BTmZKZ3JncWZYRkVx', // re_f2ixyRAw_EA1dtQCo9KnANfJgrgqfXFEq
   smtp_host: '',
   smtp_password: '',
   


### PR DESCRIPTION
## Purpose
The user was experiencing issues with Netlify deployments not working properly. After investigating the codebase, they identified that missing email service configuration was likely causing the deployment failures.

## Code changes
- **netlify.toml**: Added `RESEND_API_KEY` environment variable to build configuration
- **scripts/secure-config.js**: Added base64-encoded Resend API key to secure store with documentation
- **src/lib/secure-config.ts**: Updated Resend API key from empty placeholder to actual encoded value and updated comments to reflect production use

This change ensures that the email service credentials are properly configured for Netlify deployments, which should resolve the deployment issues.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/dc8bfc9f8b294d8aaabf6a447825cd1a/spark-verse)

👀 [Preview Link](https://dc8bfc9f8b294d8aaabf6a447825cd1a-spark-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc8bfc9f8b294d8aaabf6a447825cd1a</projectId>-->
<!--<branchName>spark-verse</branchName>-->