### PR TITLE
Move blog link from header to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -34,6 +34,12 @@ export const Footer = () => {
               >
                 Rank Tracker
               </Link>
+              <Link
+                to="/blog"
+                className="block text-gray-600 hover:text-gray-900 text-sm"
+              >
+                Blog
+              </Link>
             </div>
           </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -224,13 +224,6 @@ const Index = () => {
               <h1 className="text-2xl font-semibold tracking-tight text-foreground">Backlink</h1>
             </div>
             <div className="flex items-center gap-4">
-              <Button
-                variant="ghost"
-                onClick={() => navigate("/blog")}
-                className="font-medium text-gray-600 hover:text-gray-900"
-              >
-                Blog
-              </Button>
               <PurgeStorageButton
                 variant="ghost"
                 size="sm"


### PR DESCRIPTION
## Purpose
Relocate the blog navigation link from the header to the footer to improve the header's visual hierarchy and reduce clutter in the main navigation area.

## Code changes
- **Removed** blog button from the header navigation in `src/pages/Index.tsx`
- **Added** blog link to the footer navigation in `src/components/Footer.tsx`
- Updated styling to match existing footer link patterns with gray text and hover effects

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/9faf19968d794d6ea54877cb293eebc6/glow-works)

👀 [Preview Link](https://9faf19968d794d6ea54877cb293eebc6-glow-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9faf19968d794d6ea54877cb293eebc6</projectId>-->
<!--<branchName>glow-works</branchName>-->