### PR TITLE
Fix premium plan UI and restore missing tab

### DIFF
--- a/src/components/PremiumPlanTab.tsx
+++ b/src/components/PremiumPlanTab.tsx
@@ -108,62 +108,55 @@ export function PremiumPlanTab({ isSubscribed, onUpgrade }: PremiumPlanTabProps)
 
   return (
     <div className="space-y-8">
-      {/* Hero Section */}
-      <div className="relative overflow-hidden bg-gradient-to-br from-purple-600 via-blue-600 to-indigo-700 rounded-3xl p-8 text-white">
-        <div className="absolute inset-0 bg-black/20"></div>
-        <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-br from-white/10 to-transparent rounded-full -mr-32 -mt-32"></div>
-        <div className="relative z-10">
-          <div className="flex items-center gap-3 mb-4">
-            <Crown className="h-8 w-8 text-yellow-300" />
-            <Badge className="bg-yellow-300 text-purple-900 px-3 py-1">
-              <Sparkles className="h-3 w-3 mr-1" />
-              Premium Plan
-            </Badge>
-          </div>
-          
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">
-            Unlock Your SEO Potential
-          </h1>
-          
-          <p className="text-xl text-purple-100 mb-6 max-w-2xl">
-            Get unlimited backlinks, exclusive SEO training, and premium tools to dominate search rankings.
-          </p>
-          
-          <div className="flex items-center gap-6 mb-8">
-            <div className="text-center">
-              <div className="text-3xl font-bold">$29</div>
-              <div className="text-purple-200">per month</div>
+      {/* Hero Section - Hidden for premium users */}
+      {!isSubscribed && (
+        <div className="relative overflow-hidden bg-gradient-to-br from-purple-600 via-blue-600 to-indigo-700 rounded-3xl p-8 text-white">
+          <div className="absolute inset-0 bg-black/20"></div>
+          <div className="absolute top-0 right-0 w-64 h-64 bg-gradient-to-br from-white/10 to-transparent rounded-full -mr-32 -mt-32"></div>
+          <div className="relative z-10">
+            <div className="flex items-center gap-3 mb-4">
+              <Crown className="h-8 w-8 text-yellow-300" />
+              <Badge className="bg-yellow-300 text-purple-900 px-3 py-1">
+                <Sparkles className="h-3 w-3 mr-1" />
+                Premium Plan
+              </Badge>
             </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold">∞</div>
-              <div className="text-purple-200">backlinks</div>
+
+            <h1 className="text-4xl md:text-5xl font-bold mb-4">
+              Unlock Your SEO Potential
+            </h1>
+
+            <p className="text-xl text-purple-100 mb-6 max-w-2xl">
+              Get unlimited backlinks, exclusive SEO training, and premium tools to dominate search rankings.
+            </p>
+
+            <div className="flex items-center gap-6 mb-8">
+              <div className="text-center">
+                <div className="text-3xl font-bold">$29</div>
+                <div className="text-purple-200">per month</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold">∞</div>
+                <div className="text-purple-200">backlinks</div>
+              </div>
+              <div className="text-center">
+                <div className="text-3xl font-bold">50+</div>
+                <div className="text-purple-200">SEO lessons</div>
+              </div>
             </div>
-            <div className="text-center">
-              <div className="text-3xl font-bold">50+</div>
-              <div className="text-purple-200">SEO lessons</div>
-            </div>
-          </div>
-          
-          {!isSubscribed ? (
-            <Button 
+
+            <Button
               onClick={handleUpgrade}
-              size="lg" 
+              size="lg"
               className="bg-yellow-400 hover:bg-yellow-300 text-purple-900 font-semibold px-8 py-4 text-lg"
             >
               <Crown className="mr-2 h-5 w-5" />
               Upgrade to Premium
               <ArrowRight className="ml-2 h-5 w-5" />
             </Button>
-          ) : (
-            <div className="flex items-center gap-3">
-              <Badge className="bg-green-400 text-green-900 px-4 py-2 text-lg">
-                <CheckCircle className="mr-2 h-4 w-4" />
-                Premium Active
-              </Badge>
-            </div>
-          )}
+          </div>
         </div>
-      </div>
+      )}
 
       <Tabs value={activeFeature} onValueChange={setActiveFeature} className="w-full">
         <TabsList className="grid w-full grid-cols-3">

--- a/src/components/PremiumPlanTab.tsx
+++ b/src/components/PremiumPlanTab.tsx
@@ -271,7 +271,7 @@ export function PremiumPlanTab({ isSubscribed, onUpgrade }: PremiumPlanTabProps)
         </TabsContent>
       </Tabs>
 
-      {/* Bottom CTA */}
+      {/* Bottom CTA - Hidden for premium users */}
       {!isSubscribed && (
         <Card className="bg-gradient-to-r from-purple-600 to-blue-600 text-white border-0">
           <CardContent className="p-8 text-center">
@@ -279,9 +279,9 @@ export function PremiumPlanTab({ isSubscribed, onUpgrade }: PremiumPlanTabProps)
             <p className="text-purple-100 mb-6 max-w-2xl mx-auto">
               Join thousands of successful marketers who've upgraded their SEO game with our Premium Plan.
             </p>
-            <Button 
+            <Button
               onClick={handleUpgrade}
-              size="lg" 
+              size="lg"
               className="bg-yellow-400 hover:bg-yellow-300 text-purple-900 font-semibold px-8 py-4"
             >
               <Crown className="mr-2 h-5 w-5" />

--- a/src/components/SEOToolsSection.tsx
+++ b/src/components/SEOToolsSection.tsx
@@ -363,7 +363,17 @@ const SEOToolsSection = ({ user }: SEOToolsSectionProps) => {
               <div className="text-3xl font-bold text-primary mb-1">$29</div>
               <div className="text-sm text-muted-foreground mb-4">per month</div>
               <Button onClick={() => {
-                console.log('SEO Tools Start Subscription clicked, opening premium popup');
+                console.log('SEO Tools Start Subscription clicked');
+                if (isPremium) {
+                  toast({
+                    title: "Already Premium",
+                    description: "You already have an active premium subscription. Enjoy all premium features!",
+                    variant: "default",
+                  });
+                  console.log('User is already premium, showing notification');
+                  return;
+                }
+                console.log('Opening premium popup for non-premium user');
                 openPremiumPopup(user?.email);
               }} size="lg" className="w-full">
                 <CreditCard className="h-4 w-4 mr-2" />

--- a/src/components/SEOToolsSection.tsx
+++ b/src/components/SEOToolsSection.tsx
@@ -375,9 +375,18 @@ const SEOToolsSection = ({ user }: SEOToolsSectionProps) => {
                 }
                 console.log('Opening premium popup for non-premium user');
                 openPremiumPopup(user?.email);
-              }} size="lg" className="w-full">
-                <CreditCard className="h-4 w-4 mr-2" />
-                Start Subscription
+              }} size="lg" className="w-full" variant={isPremium ? "outline" : "default"}>
+                {isPremium ? (
+                  <>
+                    <CheckCircle2 className="h-4 w-4 mr-2" />
+                    Premium Active
+                  </>
+                ) : (
+                  <>
+                    <CreditCard className="h-4 w-4 mr-2" />
+                    Start Subscription
+                  </>
+                )}
               </Button>
               <p className="text-xs text-muted-foreground mt-2">
                 Cancel anytime • No setup fees • 30-day money back guarantee

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1551,38 +1551,16 @@ const Dashboard = () => {
                 <DashboardTrialPosts user={user} />
               </div>
             ) : activeSection === "premium-plan" ? (
-              <div className="space-y-6 relative">
-                {/* Coming Soon Overlay */}
-                <div className="absolute inset-0 bg-background/80 backdrop-blur-sm z-10 flex items-center justify-center rounded-lg">
-                  <div className="text-center p-8">
-                    <div className="w-16 h-16 mx-auto mb-4 bg-gradient-to-r from-purple-500 to-blue-500 rounded-full flex items-center justify-center">
-                      <Crown className="h-8 w-8 text-white" />
-                    </div>
-                    <h3 className="text-2xl font-bold mb-2 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
-                      Premium Features Coming Soon
-                    </h3>
-                    <p className="text-muted-foreground mb-4 max-w-md">
-                      We're working hard to bring you advanced premium features. This system is currently under development.
-                    </p>
-                    <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-                      <div className="w-2 h-2 bg-purple-500 rounded-full animate-pulse"></div>
-                      <span>Stay tuned for updates</span>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Blurred Premium Content */}
-                <div className="opacity-30 pointer-events-none">
-                  <StreamlinedPremiumProvider>
-                    <PremiumPlanTab
-                      isSubscribed={isPremiumSubscriber}
-                      onUpgrade={() => {
-                        // Refresh premium status after successful upgrade
-                        PremiumService.checkPremiumStatus(user?.id || '').then(setIsPremiumSubscriber);
-                      }}
-                    />
-                  </StreamlinedPremiumProvider>
-                </div>
+              <div className="space-y-6">
+                <StreamlinedPremiumProvider>
+                  <PremiumPlanTab
+                    isSubscribed={isPremiumSubscriber}
+                    onUpgrade={() => {
+                      // Refresh premium status after successful upgrade
+                      PremiumService.checkPremiumStatus(user?.id || '').then(setIsPremiumSubscriber);
+                    }}
+                  />
+                </StreamlinedPremiumProvider>
               </div>
             ) : null}
           </>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1077,17 +1077,15 @@ const Dashboard = () => {
                 <span className="hidden sm:inline">Trial</span>
                 <div className="absolute -top-1 -right-1 w-2 h-2 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full"></div>
               </Button>
-              {!isPremiumSubscriber && (
-                <Button
-                  variant={activeSection === "premium-plan" ? "secondary" : "ghost"}
-                  onClick={() => setActiveSection("premium-plan")}
-                  className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary px-4 py-3 relative"
-                >
-                  <Crown className="h-4 w-4 sm:mr-2" />
-                  <span className="hidden sm:inline">Premium Plan</span>
-                  <div className="absolute -top-1 -right-1 w-2 h-2 bg-gradient-to-r from-yellow-500 to-orange-500 rounded-full"></div>
-                </Button>
-              )}
+              <Button
+                variant={activeSection === "premium-plan" ? "secondary" : "ghost"}
+                onClick={() => setActiveSection("premium-plan")}
+                className="rounded-none border-b-2 border-transparent data-[state=active]:border-primary px-4 py-3 relative"
+              >
+                <Crown className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">Premium Plan</span>
+                <div className="absolute -top-1 -right-1 w-2 h-2 bg-gradient-to-r from-yellow-500 to-orange-500 rounded-full"></div>
+              </Button>
 
             </nav>
           </div>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR addresses several premium plan UI issues:
- Restores the missing premium plan tab that was accidentally hidden
- Removes the "coming soon" overlay that was blocking premium functionality
- Hides promotional banners and CTAs for users who already have premium subscriptions
- Adds proper notifications when premium users try to subscribe again
- Ensures premium checkout process works correctly for non-premium users

## Code changes

### PremiumPlanTab.tsx
- Conditionally hide hero section and bottom CTA for premium subscribers using `{!isSubscribed && (...)}`
- Maintain full functionality while removing promotional content for existing premium users

### SEOToolsSection.tsx
- Add premium status check in subscription button click handler
- Show toast notification for users who already have premium: "Already Premium - You already have an active premium subscription"
- Change button appearance and text for premium users (outline variant with "Premium Active" text)
- Prevent duplicate subscription attempts

### Dashboard.tsx
- Restore premium plan tab visibility for all users (removed conditional hiding)
- Remove "coming soon" overlay and blur effects that were blocking premium functionality
- Enable full premium plan tab functionality for both premium and non-premium users

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 170`

🔗 [Edit in Builder.io](https://builder.io/app/projects/05c77c2ec2d34a86bd73dbe3f8d53107/glow-space)

👀 [Preview Link](https://05c77c2ec2d34a86bd73dbe3f8d53107-glow-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>05c77c2ec2d34a86bd73dbe3f8d53107</projectId>-->
<!--<branchName>glow-space</branchName>-->