### PR TITLE
Add Netlify plugin to fix Stripe dependency build failure

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,6 @@
+[[plugins]]
+  package = "@netlify/plugin-functions-install-core"
+
 [build]
   publish = "dist"
   command = "npm run build"


### PR DESCRIPTION
## Purpose

Resolve build failure caused by missing Stripe dependency in Netlify Functions. The build was failing because the "stripe" package was not being installed for the Netlify Functions, preventing successful deployment.

## Code changes

- Added `@netlify/plugin-functions-install-core` plugin to `netlify.toml`
- Plugin automatically installs missing dependencies for Netlify Functions during build
- Ensures Stripe and other function dependencies are available at build time

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 200`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fb40e15b21894c639137b9f27ee75e16/vibe-sanctuary)

👀 [Preview Link](https://fb40e15b21894c639137b9f27ee75e16-vibe-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fb40e15b21894c639137b9f27ee75e16</projectId>-->
<!--<branchName>vibe-sanctuary</branchName>-->