### PR TITLE
Remove decorative lines from AnimatedBlogHeadline

### DIFF
--- a/src/components/AnimatedBlogHeadline.tsx
+++ b/src/components/AnimatedBlogHeadline.tsx
@@ -74,17 +74,6 @@ export function AnimatedBlogHeadline() {
           ))}
         </h2>
 
-        {/* Animated decorative lines with bouncing */}
-        <div
-          className={`absolute -top-2 left-1/2 transform -translate-x-1/2 w-0 h-0.5 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full transition-all duration-1000 delay-1000 ${
-            showText ? 'w-20 opacity-70 animate-[bounce_2s_ease-in-out_infinite]' : 'w-0 opacity-0'
-          }`}
-        ></div>
-        <div
-          className={`absolute -bottom-2 left-1/2 transform -translate-x-1/2 w-0 h-0.5 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full transition-all duration-1000 delay-1200 ${
-            showText ? 'w-14 opacity-50 animate-[bounce_2s_ease-in-out_infinite_0.5s]' : 'w-0 opacity-0'
-          }`}
-        ></div>
       </div>
 
       {/* Animated subtitle */}

--- a/src/components/AnimatedBlogHeadline.tsx
+++ b/src/components/AnimatedBlogHeadline.tsx
@@ -74,15 +74,15 @@ export function AnimatedBlogHeadline() {
           ))}
         </h2>
 
-        {/* Animated decorative lines */}
-        <div 
+        {/* Animated decorative lines with bouncing */}
+        <div
           className={`absolute -top-2 left-1/2 transform -translate-x-1/2 w-0 h-0.5 bg-gradient-to-r from-blue-400 to-purple-400 rounded-full transition-all duration-1000 delay-1000 ${
-            showText ? 'w-20 opacity-70 animate-pulse-glow' : 'w-0 opacity-0'
+            showText ? 'w-20 opacity-70 animate-[bounce_2s_ease-in-out_infinite]' : 'w-0 opacity-0'
           }`}
         ></div>
-        <div 
+        <div
           className={`absolute -bottom-2 left-1/2 transform -translate-x-1/2 w-0 h-0.5 bg-gradient-to-r from-purple-400 to-pink-400 rounded-full transition-all duration-1000 delay-1200 ${
-            showText ? 'w-14 opacity-50 animate-pulse-glow' : 'w-0 opacity-0'
+            showText ? 'w-14 opacity-50 animate-[bounce_2s_ease-in-out_infinite_0.5s]' : 'w-0 opacity-0'
           }`}
         ></div>
       </div>


### PR DESCRIPTION
## Purpose
Remove animated decorative lines from the blog headline component as requested by the user to clean up the visual design.

## Code changes
- Removed two animated decorative line elements from `AnimatedBlogHeadline.tsx`
- Deleted the top gradient line (blue to purple) with pulse animation
- Deleted the bottom gradient line (purple to pink) with pulse animation
- Maintained all other existing functionality and animations

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 256`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4051db2410b7452498bf17d06b31f8db/glow-zone)

👀 [Preview Link](https://4051db2410b7452498bf17d06b31f8db-glow-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4051db2410b7452498bf17d06b31f8db</projectId>-->
<!--<branchName>glow-zone</branchName>-->