### PR TITLE
Fix blog post URL routing by removing redirect rule

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,19 +17,13 @@
 # using the schedule() function from @netlify/functions
 # For manual testing, use: /.netlify/functions/cleanup-expired
 
-# Redirects for blog posts
-[[redirects]]
-  from = "/blog/:slug"
-  to = "/blog/index.html?slug=:slug"
-  status = 200
-
 # API redirects
 [[redirects]]
   from = "/api/*"
   to = "/.netlify/functions/:splat"
   status = 200
 
-# SPA fallback
+# SPA fallback - this handles all routes including blog posts
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## Purpose
Fix broken blog post URLs that were failing when refreshed or accessed directly in the browser. The user reported that refreshing blog post URLs or entering them directly was breaking the page.

## Code changes
- Removed the specific blog post redirect rule that was routing `/blog/:slug` to `/blog/index.html?slug=:slug`
- Updated the SPA fallback comment to clarify it now handles all routes including blog posts
- Simplified routing by letting the SPA fallback handle blog post URLs directly through the main application routing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 269`

🔗 [Edit in Builder.io](https://builder.io/app/projects/07bed4c9efc247028e3d5c18747b1978/curry-home)

👀 [Preview Link](https://07bed4c9efc247028e3d5c18747b1978-curry-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>07bed4c9efc247028e3d5c18747b1978</projectId>-->
<!--<branchName>curry-home</branchName>-->