### PR TITLE
Add published_at column to automation_published_links

### DIFF
--- a/scripts/fix-automation-schema.js
+++ b/scripts/fix-automation-schema.js
@@ -243,6 +243,7 @@ async function createMissingTable(tableName) {
                 platform TEXT DEFAULT 'telegraph',
                 status TEXT DEFAULT 'active',
                 created_at TIMESTAMPTZ DEFAULT NOW(),
+                published_at TIMESTAMPTZ DEFAULT NOW(),
                 last_checked TIMESTAMPTZ DEFAULT NOW()
             );
         `,

--- a/scripts/fix-automation-schema.js
+++ b/scripts/fix-automation-schema.js
@@ -83,7 +83,7 @@ async function checkAndFixSchema() {
         console.log('3. Checking other automation tables...');
         const automationTables = [
             'automation_logs',
-            'automation_content', 
+            'automation_content',
             'automation_published_links',
             'link_placements',
             'campaign_reports'
@@ -101,6 +101,11 @@ async function checkAndFixSchema() {
                 await createMissingTable(tableName);
             } else {
                 console.log(`✅ ${tableName} table exists`);
+
+                // Special check for automation_published_links to ensure published_at column exists
+                if (tableName === 'automation_published_links') {
+                    await checkAndFixPublishedLinksTable();
+                }
             }
         }
 

--- a/src/components/BacklinkNotification.tsx
+++ b/src/components/BacklinkNotification.tsx
@@ -30,15 +30,15 @@ export const BacklinkNotification: React.FC<BacklinkNotificationProps> = ({
   useEffect(() => {
     if (!isVisible) return;
 
-    const handleNewEvent = (event: FeedEvent) => {
+    const handleNewEvent = (event: RealTimeFeedEvent) => {
       // Listen for URL published events
       if (event.type === 'url_published') {
         const notification: NotificationData = {
           id: `notification-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
           campaignName: event.campaignName || 'Campaign',
-          keyword: event.keyword || 'Unknown',
-          publishedUrl: event.url || '',
-          platform: event.platform || 'Telegraph',
+          keyword: event.details?.keyword || 'Unknown',
+          publishedUrl: event.details?.publishedUrl || '',
+          platform: event.details?.platform || 'Telegraph',
           timestamp: new Date()
         };
 

--- a/src/components/BacklinkNotification.tsx
+++ b/src/components/BacklinkNotification.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Globe, ExternalLink, X, CheckCircle } from 'lucide-react';
-import { realTimeFeedService, type FeedEvent } from '@/services/realTimeFeedService';
+import { realTimeFeedService, type RealTimeFeedEvent } from '@/services/realTimeFeedService';
 
 interface BacklinkNotificationProps {
   isVisible?: boolean;

--- a/src/components/CampaignManagerTabbed.tsx
+++ b/src/components/CampaignManagerTabbed.tsx
@@ -96,8 +96,7 @@ const CampaignManagerTabbed: React.FC<CampaignManagerTabbedProps> = ({
             duration: 5000,
           });
 
-          // Update parent status
-          onStatusUpdate?.(`New backlink published: ${event.details?.publishedUrl || event.url || 'new URL'}`, 'success');
+          // Note: Don't create duplicate status messages - BacklinkNotification handles popup notifications
         }
 
         // Refresh campaigns to show new data

--- a/src/components/CampaignManagerTabbed.tsx
+++ b/src/components/CampaignManagerTabbed.tsx
@@ -558,37 +558,12 @@ const CampaignManagerTabbed: React.FC<CampaignManagerTabbedProps> = ({
                         <div className="flex flex-col gap-2 ml-4">
                           {(() => {
                             const summary = campaignStatusSummaries.get(campaign.id);
+                            const isActive = ['active', 'pending', 'generating', 'publishing'].includes(campaign.status);
+                            const isPaused = campaign.status === 'paused';
+                            const isCompleted = campaign.status === 'completed';
 
-                            // Resume button for paused campaigns
-                            if (campaign.status === 'paused') {
-                              const canResume = summary?.nextPlatform;
-                              const tooltipText = canResume
-                                ? `Resume to continue posting to ${summary.nextPlatform}`
-                                : 'All available platforms have been used';
-
-                              return (
-                                <Button
-                                  size="sm"
-                                  variant={canResume ? "default" : "outline"}
-                                  onClick={() => handleResumeCampaign(campaign.id)}
-                                  disabled={actionLoading === campaign.id || !canResume}
-                                  title={tooltipText}
-                                  className={canResume ? "bg-green-600 hover:bg-green-700 text-white" : ""}
-                                >
-                                  {actionLoading === campaign.id ? (
-                                    <Loader2 className="w-4 h-4 animate-spin" />
-                                  ) : (
-                                    <>
-                                      <Play className="w-4 h-4 mr-1" />
-                                      {canResume ? 'Resume' : 'Complete'}
-                                    </>
-                                  )}
-                                </Button>
-                              );
-                            }
-
-                            // Pause button for active campaigns
-                            if (['active', 'pending', 'generating', 'publishing'].includes(campaign.status)) {
+                            // Always show pause button for active campaigns
+                            if (isActive) {
                               return (
                                 <Button
                                   size="sm"
@@ -604,6 +579,37 @@ const CampaignManagerTabbed: React.FC<CampaignManagerTabbedProps> = ({
                                     <>
                                       <Pause className="w-4 h-4 mr-1" />
                                       Pause
+                                    </>
+                                  )}
+                                </Button>
+                              );
+                            }
+
+                            // Always show resume button for paused or completed campaigns
+                            if (isPaused || isCompleted) {
+                              const hasNextPlatform = summary?.nextPlatform;
+                              const buttonText = isCompleted ? 'Re-run' : hasNextPlatform ? 'Resume' : 'Re-run';
+                              const tooltipText = isCompleted
+                                ? 'Campaign completed - click to check for new opportunities or re-run'
+                                : hasNextPlatform
+                                  ? `Resume to continue posting to ${summary.nextPlatform}`
+                                  : 'No more platforms available - click to check for new opportunities';
+
+                              return (
+                                <Button
+                                  size="sm"
+                                  variant="default"
+                                  onClick={() => handleResumeCampaign(campaign.id)}
+                                  disabled={actionLoading === campaign.id}
+                                  title={tooltipText}
+                                  className={isCompleted ? "bg-blue-600 hover:bg-blue-700 text-white" : "bg-green-600 hover:bg-green-700 text-white"}
+                                >
+                                  {actionLoading === campaign.id ? (
+                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                  ) : (
+                                    <>
+                                      <Play className="w-4 h-4 mr-1" />
+                                      {buttonText}
                                     </>
                                   )}
                                 </Button>

--- a/src/components/CampaignManagerTabbed.tsx
+++ b/src/components/CampaignManagerTabbed.tsx
@@ -92,12 +92,12 @@ const CampaignManagerTabbed: React.FC<CampaignManagerTabbedProps> = ({
         if (event.type === 'url_published') {
           toast({
             title: "New Backlink Published!",
-            description: `Published "${event.keyword}" to ${event.platform}`,
+            description: `Published "${event.details?.keyword || event.keyword || 'content'}" to ${event.details?.platform || event.platform || 'platform'}`,
             duration: 5000,
           });
 
           // Update parent status
-          onStatusUpdate?.(`New backlink published: ${event.url}`, 'success');
+          onStatusUpdate?.(`New backlink published: ${event.details?.publishedUrl || event.url || 'new URL'}`, 'success');
         }
 
         // Refresh campaigns to show new data

--- a/src/utils/fixPublishedLinksSchema.ts
+++ b/src/utils/fixPublishedLinksSchema.ts
@@ -1,0 +1,126 @@
+/**
+ * Utility to fix the missing published_at column in automation_published_links table
+ * This addresses the issue where published links aren't being saved due to missing column
+ */
+
+import { supabase } from '@/integrations/supabase/client';
+
+export async function fixPublishedLinksSchema(): Promise<{ success: boolean; message: string }> {
+  try {
+    console.log('🔧 Checking automation_published_links table schema...');
+    
+    // Check if published_at column exists
+    const { data: columns, error: columnsError } = await supabase
+      .from('information_schema.columns')
+      .select('column_name')
+      .eq('table_name', 'automation_published_links')
+      .eq('table_schema', 'public')
+      .eq('column_name', 'published_at');
+
+    if (columnsError) {
+      console.error('❌ Error checking columns:', columnsError);
+      return {
+        success: false,
+        message: `Failed to check table schema: ${columnsError.message}`
+      };
+    }
+
+    if (!columns || columns.length === 0) {
+      console.log('⚠️ published_at column missing. Adding it now...');
+      
+      // Add the missing column using RPC function
+      const { error: addColumnError } = await supabase.rpc('exec_sql', {
+        query: `
+          ALTER TABLE automation_published_links 
+          ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ DEFAULT NOW();
+          
+          CREATE INDEX IF NOT EXISTS idx_automation_published_links_published_at 
+          ON automation_published_links(published_at DESC);
+          
+          UPDATE automation_published_links 
+          SET published_at = created_at 
+          WHERE published_at IS NULL;
+        `
+      });
+
+      if (addColumnError) {
+        console.error('❌ Error adding column:', addColumnError);
+        return {
+          success: false,
+          message: `Failed to add published_at column: ${addColumnError.message}`
+        };
+      }
+
+      console.log('✅ published_at column added successfully');
+      return {
+        success: true,
+        message: 'Schema fixed: published_at column added to automation_published_links table'
+      };
+    } else {
+      console.log('✅ published_at column already exists');
+      return {
+        success: true,
+        message: 'Schema is correct: published_at column exists'
+      };
+    }
+  } catch (error) {
+    console.error('❌ Schema fix failed:', error);
+    return {
+      success: false,
+      message: `Schema fix failed: ${error instanceof Error ? error.message : String(error)}`
+    };
+  }
+}
+
+export async function testPublishedLinksInsert(): Promise<{ success: boolean; message: string }> {
+  try {
+    console.log('🧪 Testing published links insert...');
+    
+    // Try to insert a test record
+    const testData = {
+      campaign_id: '00000000-0000-0000-0000-000000000001', // Dummy UUID for test
+      published_url: 'https://test.example.com',
+      anchor_text: 'test link',
+      target_url: 'https://target.example.com',
+      platform: 'test',
+      status: 'test',
+      published_at: new Date().toISOString()
+    };
+
+    const { error: insertError } = await supabase
+      .from('automation_published_links')
+      .insert(testData);
+
+    if (insertError) {
+      if (insertError.message.includes('violates foreign key constraint')) {
+        // Expected error due to dummy campaign_id, but column exists
+        return {
+          success: true,
+          message: 'Schema test passed: published_at column accepts data (foreign key error is expected)'
+        };
+      } else {
+        return {
+          success: false,
+          message: `Insert test failed: ${insertError.message}`
+        };
+      }
+    }
+
+    // Clean up test record if it was inserted
+    await supabase
+      .from('automation_published_links')
+      .delete()
+      .eq('platform', 'test')
+      .eq('status', 'test');
+
+    return {
+      success: true,
+      message: 'Schema test passed: published_at column works correctly'
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message: `Insert test failed: ${error instanceof Error ? error.message : String(error)}`
+    };
+  }
+}

--- a/supabase/migrations/fix_published_at_column.sql
+++ b/supabase/migrations/fix_published_at_column.sql
@@ -1,0 +1,18 @@
+-- Migration: Add published_at column to automation_published_links table
+-- This fixes the issue where published links aren't being saved because the column is missing
+
+-- Add published_at column if it doesn't exist
+ALTER TABLE automation_published_links 
+ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ DEFAULT NOW();
+
+-- Create index for performance on published_at field since it's used for sorting
+CREATE INDEX IF NOT EXISTS idx_automation_published_links_published_at 
+ON automation_published_links(published_at DESC);
+
+-- Update existing records to have published_at set to created_at if null
+UPDATE automation_published_links 
+SET published_at = created_at 
+WHERE published_at IS NULL;
+
+-- Add comment to document the purpose
+COMMENT ON COLUMN automation_published_links.published_at IS 'Timestamp when the link was published to the platform';


### PR DESCRIPTION
## Purpose

Based on the conversation, this PR addresses two key issues:
1. **Notification deduplication**: Ensure notifications are only posted once and prevent duplicate status messages
2. **Missing database column**: Fix the missing `published_at` column in the `automation_published_links` table that was preventing links from being properly saved and displayed in the links tab

## Code Changes

### Database Schema Fixes
- **Added migration**: `fix_published_at_column.sql` to add the missing `published_at` TIMESTAMPTZ column
- **Schema validation**: Enhanced `fix-automation-schema.js` with `checkAndFixPublishedLinksTable()` function to automatically detect and fix missing columns
- **Index creation**: Added performance index on `published_at` for efficient sorting
- **Data migration**: Backfill existing records with `published_at = created_at`

### Application Logic Improvements
- **Campaign resume logic**: Enhanced `smartResumeCampaign()` to properly handle completed campaigns and check for unused platforms
- **Notification handling**: Updated `BacklinkNotification.tsx` to use correct event structure and prevent duplicate notifications
- **Type safety**: Fixed type imports from `FeedEvent` to `RealTimeFeedEvent` for better type consistency
- **Status messaging**: Improved campaign manager to avoid duplicate status updates when BacklinkNotification handles popups

### Utility Functions
- **Schema testing**: Added `fixPublishedLinksSchema.ts` utility for manual schema fixes and testing
- **Error handling**: Improved error handling and logging throughout the automation flow

This ensures that published links are properly saved to the database and displayed in the links tab, while maintaining clean notification handling.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 324`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8b587a5bea1b47d2b27670e45ee94113/pulse-field)

👀 [Preview Link](https://8b587a5bea1b47d2b27670e45ee94113-pulse-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8b587a5bea1b47d2b27670e45ee94113</projectId>-->
<!--<branchName>pulse-field</branchName>-->