### PR TITLE
Fix HeaderUpgradeButton import and replace with PremiumUpgradeButton

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,7 @@ import { AuthService } from '@/services/authService';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { navigateToSection, NAVIGATION_CONFIGS } from '@/utils/navigationUtils';
-import { HeaderUpgradeButton } from '@/components/PremiumUpgradeButton';
+import { PremiumUpgradeButton } from '@/components/PremiumUpgradeButton';
 import { ModernCreditPurchaseModal } from '@/components/ModernCreditPurchaseModal';
 
 interface HeaderProps {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -178,7 +178,11 @@ export function Header({ showHomeLink = true }: HeaderProps) {
             ) : user ? (
               // Authenticated user buttons
               <>
-                <HeaderUpgradeButton />
+                <PremiumUpgradeButton
+                  variant="outline"
+                  size="sm"
+                  className="bg-transparent hover:bg-purple-50/50 border border-purple-200/60 text-purple-600 hover:text-purple-700 hover:border-purple-300/80 transition-all duration-200 font-medium px-4 py-2 backdrop-blur-sm shadow-sm hover:shadow-md"
+                />
                 <Button
                   variant="outline"
                   size="sm"


### PR DESCRIPTION
## Purpose
Resolve build failure caused by missing export of `HeaderUpgradeButton` component. The user needed to fix the import error where `HeaderUpgradeButton` was not exported from `PremiumUpgradeButton.tsx`, which was causing deployment issues.

## Code changes
- Updated import statement in `Header.tsx` to use `PremiumUpgradeButton` instead of `HeaderUpgradeButton`
- Replaced `<HeaderUpgradeButton />` component usage with `<PremiumUpgradeButton>` 
- Added inline styling props to `PremiumUpgradeButton` including variant, size, and custom className with purple theme styling
- Applied responsive hover effects and transition animations to the button

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 467`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ddc3fcd2ef9547448adb3eaa751bdcfa/swoosh-den)

👀 [Preview Link](https://ddc3fcd2ef9547448adb3eaa751bdcfa-swoosh-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ddc3fcd2ef9547448adb3eaa751bdcfa</projectId>-->
<!--<branchName>swoosh-den</branchName>-->