### PR TITLE
Fix payment price calculation precision for accurate amounts

### DIFF
--- a/src/components/MobileOptimizedPaymentButton.tsx
+++ b/src/components/MobileOptimizedPaymentButton.tsx
@@ -135,7 +135,7 @@ export function MobileOptimizedPaymentButton({
     } else {
       const amount = credits <= 500 && [50, 100, 250, 500].includes(credits) 
         ? [70, 140, 350, 700][[50, 100, 250, 500].indexOf(credits)]
-        : Math.ceil(credits * 1.40);
+        : Number((credits * 1.40).toFixed(2));
       return `Buy ${credits} Credits ($${amount})`;
     }
   };

--- a/src/components/StripeIntegrationTest.tsx
+++ b/src/components/StripeIntegrationTest.tsx
@@ -139,8 +139,8 @@ export function StripeIntegrationTest() {
 
     try {
       const customCredits = 123;
-      const customAmount = Math.ceil(customCredits * 1.40);
-      
+      const customAmount = Number((customCredits * 1.40).toFixed(2));
+
       addTestResult('Custom Credits', 'info', `Testing custom ${customCredits} credits purchase...`);
       
       const result = await stripeWrapper.createPayment({

--- a/src/services/directStripeCheckout.ts
+++ b/src/services/directStripeCheckout.ts
@@ -30,7 +30,7 @@ export class DirectStripeCheckout {
       }
     } else {
       // For custom amounts, use createPayment directly
-      const amount = Math.ceil(credits * 1.40); // $1.40 per credit
+      const amount = Number((credits * 1.40).toFixed(2)); // $1.40 per credit
       const result = await stripeWrapper.createPayment({
         amount,
         credits,

--- a/src/services/enhancedPaymentService.ts
+++ b/src/services/enhancedPaymentService.ts
@@ -144,7 +144,7 @@ export class EnhancedPaymentService {
         };
       } else {
         // Use createPayment for custom amounts
-        const amount = Math.ceil(credits * 1.40); // $1.40 per credit
+        const amount = Number((credits * 1.40).toFixed(2)); // $1.40 per credit
         const result = await stripeWrapper.createPayment({
           amount,
           credits,

--- a/src/services/stripeWrapper.ts
+++ b/src/services/stripeWrapper.ts
@@ -119,11 +119,6 @@ class StripeWrapper {
       paymentMethod: 'stripe'
     };
 
-    // Prefer Payment Link for credits to auto-fill quantity
-    if (typeof options.credits === 'number' && options.credits > 0) {
-      const link = this.buildCreditsPaymentLink(options.credits, options.userEmail);
-      if (link) return { success: true, url: link, method: 'direct_stripe' };
-    }
 
     // Try multiple endpoints before falling back to Supabase
     const endpoints = [
@@ -376,7 +371,7 @@ class StripeWrapper {
       case 100: return 140;
       case 250: return 350;
       case 500: return 700;
-      default: return Math.ceil(credits * 1.40); // $1.40 per credit
+      default: return Number((credits * 1.40).toFixed(2));
     }
   }
 }


### PR DESCRIPTION
## Purpose

Fix payment form accuracy issues where the displayed price and quantity didn't match the actual payment amount. The user reported that the form wasn't reflecting the accurate quantity and price from user entry/selection on the payment page.

## Code changes

- **Replaced `Math.ceil()` with `Number().toFixed(2)`** across all payment calculation functions to ensure precise decimal amounts instead of rounded-up integers
- **Updated price calculation** in `MobileOptimizedPaymentButton`, `StripeIntegrationTest`, `directStripeCheckout`, `enhancedPaymentService`, and `stripeWrapper` components
- **Removed Payment Link preference logic** in `stripeWrapper.ts` that was potentially causing display inconsistencies
- **Standardized credit pricing calculation** to use exact $1.40 per credit with 2 decimal precision

These changes ensure that custom credit amounts show accurate pricing (e.g., 123 credits = $172.20 instead of $173) and eliminate discrepancies between form display and actual payment amounts.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 476`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3d688e61590a4c73ac3838a39912bdff/stellar-haven)

👀 [Preview Link](https://3d688e61590a4c73ac3838a39912bdff-stellar-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3d688e61590a4c73ac3838a39912bdff</projectId>-->
<!--<branchName>stellar-haven</branchName>-->