### PR TITLE
Fix credit pricing calculations and improve input validation

### DIFF
--- a/src/components/CustomCreditsModal.tsx
+++ b/src/components/CustomCreditsModal.tsx
@@ -47,7 +47,8 @@ export const CustomCreditsModal = ({
   // Calculate total amount based on credits
   const calculateAmount = (creditCount: string): number => {
     const numCredits = parseFloat(creditCount) || 0;
-    return numCredits * CREDIT_PRICE;
+    // Always round to cents to match Stripe amount
+    return Number((numCredits * CREDIT_PRICE).toFixed(2));
   };
 
   const totalAmount = calculateAmount(credits);
@@ -66,7 +67,7 @@ export const CustomCreditsModal = ({
 
   const startCheckout = async () => {
     const creditCount = parseInt(credits);
-    const amount = Math.ceil(creditCount * CREDIT_PRICE);
+    const amount = calculateAmount(credits);
     const result = await stripeWrapper.createPayment({ amount, credits: creditCount, productName: `${creditCount} Backlink Credits`, userEmail: user?.email || undefined });
     if (result.success && result.url) {
       stripeWrapper.openCheckoutWindow(result.url, result.sessionId);

--- a/src/components/ModernCreditPurchaseModal.tsx
+++ b/src/components/ModernCreditPurchaseModal.tsx
@@ -36,8 +36,8 @@ export function ModernCreditPurchaseModal({
   const { openLoginModal } = useAuthModal();
 
   const [selectedPackage, setSelectedPackage] = useState<number | null>(null);
-  const [customCredits, setCustomCredits] = useState("300");
-  const [totalPrice, setTotalPrice] = useState(420.00);
+  const [customCredits, setCustomCredits] = useState("");
+  const [totalPrice, setTotalPrice] = useState(0);
   const [rate] = useState(1.40);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -82,7 +82,7 @@ export function ModernCreditPurchaseModal({
   };
 
   const handleCustomCreditsChange = (value: string) => {
-    // Allow only numbers
+    // Allow only integers
     const numericValue = value.replace(/[^0-9]/g, '');
     setCustomCredits(numericValue);
     setSelectedPackage(null); // Clear package selection for custom amount
@@ -216,7 +216,9 @@ export function ModernCreditPurchaseModal({
               <div className="space-y-2">
                 <div className="relative">
                   <Input
-                    type="text"
+                    type="number"
+                    min={1}
+                    step={1}
                     value={customCredits}
                     onChange={(e) => handleCustomCreditsChange(e.target.value)}
                     placeholder="Enter number of credits"

--- a/src/services/directCheckoutService.ts
+++ b/src/services/directCheckoutService.ts
@@ -171,11 +171,11 @@ class DirectCheckoutService {
    * Get price for credits (simplified pricing)
    */
   private static getCreditsPrice(credits: number): number {
-    if (credits <= 50) return 70;
-    if (credits <= 100) return 140;
-    if (credits <= 250) return 350;
-    if (credits <= 500) return 700;
-    return credits * 1.40; // $1.40 per credit default
+    if (credits === 50) return 70;
+    if (credits === 100) return 140;
+    if (credits === 250) return 350;
+    if (credits === 500) return 700;
+    return Number((credits * 1.40).toFixed(2)); // $1.40 per credit default
   }
   
   /**

--- a/src/services/stripeWrapper.ts
+++ b/src/services/stripeWrapper.ts
@@ -150,9 +150,8 @@ class StripeWrapper {
 
     // Final fallback: Stripe Payment Link (no server dependency)
     if (STRIPE_CHECKOUT_URLS.credits) {
-      const url = new URL(STRIPE_CHECKOUT_URLS.credits);
-      if (payload.guestEmail) url.searchParams.set('prefilled_email', payload.guestEmail as string);
-      return { success: true, url: url.toString(), sessionId: undefined };
+      const link = this.buildCreditsPaymentLink(payload.credits || 0, payload.guestEmail as string | undefined);
+      if (link) return { success: true, url: link, sessionId: undefined };
     }
 
     return { success: false, error: 'Failed to start checkout' };

--- a/src/services/universalStripeCheckout.ts
+++ b/src/services/universalStripeCheckout.ts
@@ -6,7 +6,7 @@
  */
 
 import { stripeWrapper, type PaymentOptions as WrapperPaymentOptions, type SubscriptionOptions as WrapperSubscriptionOptions, type PaymentResult as WrapperPaymentResult } from './stripeWrapper';
-import { useAuth } from '@/hooks/useAuth';
+import { supabase } from '@/integrations/supabase/client';
 
 export interface PaymentOptions {
   amount?: number;


### PR DESCRIPTION
## Changes Made

### Credit Pricing Calculations
- **CustomCreditsModal.tsx**: Updated `calculateAmount` function to round to 2 decimal places using `toFixed(2)` to match Stripe amount formatting
- **CustomCreditsModal.tsx**: Replaced `Math.ceil()` calculation in `startCheckout` with the standardized `calculateAmount` function
- **directCheckoutService.ts**: Changed pricing logic from range-based (`<=`) to exact value matching (`===`) for predefined credit packages
- **directCheckoutService.ts**: Added `toFixed(2)` rounding for custom credit amounts to ensure consistent decimal precision

### Input Validation Improvements
- **ModernCreditPurchaseModal.tsx**: Changed custom credits input from `type="text"` to `type="number"` with `min={1}` and `step={1}` attributes
- **ModernCreditPurchaseModal.tsx**: Updated comment from "Allow only numbers" to "Allow only integers" to reflect the actual validation behavior
- **ModernCreditPurchaseModal.tsx**: Reset default custom credits value from "300" to empty string and total price from 420.00 to 0

### Stripe Integration Updates
- **stripeWrapper.ts**: Replaced direct URL construction with `buildCreditsPaymentLink` method call for better payment link handling
- **universalStripeCheckout.ts**: Changed import from `useAuth` hook to direct `supabase` client import

These changes ensure consistent pricing calculations across all credit purchase flows and improve the user experience with better input validation.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 477`

🔗 [Edit in Builder.io](https://builder.io/app/projects/209f230a474341a78959c5a39f1d74a6/zenith-world)

👀 [Preview Link](https://209f230a474341a78959c5a39f1d74a6-zenith-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>209f230a474341a78959c5a39f1d74a6</projectId>-->
<!--<branchName>zenith-world</branchName>-->